### PR TITLE
Update zig to 0.7.0

### DIFF
--- a/README.Debian
+++ b/README.Debian
@@ -1,7 +1,7 @@
 Zig for Debian
 ==============
 
-See <https://ziglang.org/documentation/0.6.0/> for documentation.
+See <https://ziglang.org/documentation/0.7.0/> for documentation.
 
 Use <https://github.com/ziglang/zig/issues> for bug reports regarding Zig.
 

--- a/README.md
+++ b/README.md
@@ -43,9 +43,9 @@ Alternatively, you can just download the latest [`.deb`][] file and install
 that directly with [`dpkg`][]:
 
 ```bash
-$ wget https://github.com/dryzig/zig-debian/releases/download/0.6.0-1/zig_0.6.0-1_amd64.deb
+$ wget https://github.com/dryzig/zig-debian/releases/download/0.7.0-1/zig_0.7.0-1_amd64.deb
 
-$ sudo dpkg -i zig_0.6.0-1_amd64.deb
+$ sudo dpkg -i zig_0.7.0-1_amd64.deb
 ```
 
 [`.deb`]: https://en.wikipedia.org/wiki/Deb_(file_format)
@@ -111,20 +111,20 @@ $ sudo apt update
 Maintenance
 -----------
 
-### Building `zig_0.6.0-1_amd64.deb`
+### Building `zig_0.7.0-1_amd64.deb`
 
 ```bash
-$ wget https://ziglang.org/download/0.6.0/zig-linux-x86_64-0.6.0.tar.xz
-$ tar xvf zig-linux-x86_64-0.6.0.tar.xz
+$ wget https://ziglang.org/download/0.7.0/zig-linux-x86_64-0.7.0.tar.xz
+$ tar xvf zig-linux-x86_64-0.7.0.tar.xz
 ```
 
 ```bash
-$ ln -s zig-linux-x86_64-0.6.0 zig-0.6.0
-$ tar cJhf zig_0.6.0.orig.tar.xz zig-0.6.0
+$ ln -s zig-linux-x86_64-0.7.0 zig-0.7.0
+$ tar cJhf zig_0.7.0.orig.tar.xz zig-0.7.0
 ```
 
 ```bash
-$ cd zig-0.6.0
+$ cd zig-0.7.0
 $ git clone https://github.com/dryzig/zig-debian.git debian
 $ debuild
 ```

--- a/changelog
+++ b/changelog
@@ -1,3 +1,11 @@
+zig (0.7.0-1) unstable; urgency=low
+
+  * Upgraded to latest 0.7.0 release
+
+    <https://ziglang.org/download/0.7.0/zig-linux-x86_64-0.7.0.tar.xz>
+
+ -- Kent Smith <kentsmith@gmail.com>  Wed, 18 Nov 2020 16:09:25 -0600
+
 zig (0.6.0-1) unstable; urgency=low
 
   * Initial packaging based on upstream's amd64 binaries:

--- a/source/lintian-overrides
+++ b/source/lintian-overrides
@@ -10,5 +10,5 @@ zig source: newer-standards-version *
 # yes, it's true
 zig source: testsuite-autopkgtest-missing
 
-# needed for 0.6.0, but not master
+# needed for 0.7.0, but not master
 zig source: source-is-missing doc/std/data.js *

--- a/zig.dirs
+++ b/zig.dirs
@@ -1,2 +1,2 @@
 /usr/lib/zig
-/usr/lib/zig/0.6.0
+/usr/lib/zig/0.7.0

--- a/zig.install
+++ b/zig.install
@@ -1,3 +1,3 @@
-zig /usr/lib/zig/0.6.0
-lib /usr/lib/zig/0.6.0
-doc/langref.html /usr/share/doc/zig
+zig /usr/lib/zig/0.7.0
+lib /usr/lib/zig/0.7.0
+langref.html /usr/share/doc/zig

--- a/zig.links
+++ b/zig.links
@@ -1,1 +1,1 @@
-/usr/lib/zig/0.6.0/zig /usr/bin/zig
+/usr/lib/zig/0.7.0/zig /usr/bin/zig

--- a/zig.lintian-overrides
+++ b/zig.lintian-overrides
@@ -1,21 +1,21 @@
 # none of these originate from Zig per se
-zig: spelling-error-in-binary usr/lib/zig/0.6.0/zig *
+zig: spelling-error-in-binary usr/lib/zig/0.7.0/zig *
 
 # the binary is statically linked
-zig: shared-lib-without-dependency-information usr/lib/zig/0.6.0/zig
+zig: shared-lib-without-dependency-information usr/lib/zig/0.7.0/zig
 
 # not packaging for the Debian archive yet
 zig: new-package-should-close-itp-bug
 
 # yes, it's true
-zig: extra-license-file usr/lib/zig/0.6.0/lib/zig/libc/mingw/COPYING
-zig: extra-license-file usr/lib/zig/0.6.0/lib/zig/libcxx/LICENSE.TXT
-zig: extra-license-file usr/lib/zig/0.6.0/lib/zig/libcxxabi/LICENSE.TXT
-zig: extra-license-file usr/lib/zig/0.6.0/lib/zig/libunwind/LICENSE.TXT
+zig: extra-license-file usr/lib/zig/0.7.0/lib/zig/libc/mingw/COPYING
+zig: extra-license-file usr/lib/zig/0.7.0/lib/zig/libcxx/LICENSE.TXT
+zig: extra-license-file usr/lib/zig/0.7.0/lib/zig/libcxxabi/LICENSE.TXT
+zig: extra-license-file usr/lib/zig/0.7.0/lib/zig/libunwind/LICENSE.TXT
 
 # yes, it's true
-zig: package-contains-empty-directory usr/lib/zig/0.6.0/lib/zig/std/net/
-zig: package-contains-empty-directory usr/lib/zig/0.6.0/lib/zig/std/unicode/
+zig: package-contains-empty-directory usr/lib/zig/0.7.0/lib/zig/std/net/
+zig: package-contains-empty-directory usr/lib/zig/0.7.0/lib/zig/std/unicode/
 
 # yes, it's true
 zig: binary-without-manpage usr/bin/zig


### PR DESCRIPTION
Pretty much changed every instance of 0.6.0 to 0.7.0 and fixed the path of langref.html.